### PR TITLE
JTDAP-193: Select Field — Nova v5 API parity + tests

### DIFF
--- a/resources/js/components/Fields/FieldDisplay.vue
+++ b/resources/js/components/Fields/FieldDisplay.vue
@@ -208,16 +208,23 @@ const booleanDisplayText = computed(() => {
 })
 
 const selectDisplayValue = computed(() => {
-  if (typeof props.value === 'object' && props.value.label !== undefined) {
-    return props.value.label
+  // When displayUsingLabels is enabled, prefer label display
+  if (props.field.displayUsingLabels) {
+    if (typeof props.value === 'object' && props.value.label !== undefined) {
+      return props.value.label
+    }
+    if (props.field.options && props.value !== null && props.value !== undefined) {
+      return props.field.options[props.value] ?? props.value ?? 'N/A'
+    }
+    return props.value ?? 'N/A'
   }
 
-  // Look up in field options
-  if (props.field.options && props.value !== null) {
-    return props.field.options[props.value] || props.value
+  // Otherwise, show the raw value
+  if (typeof props.value === 'object' && props.value.value !== undefined) {
+    return props.value.value
   }
 
-  return props.value || 'N/A'
+  return props.value ?? 'N/A'
 })
 
 // Methods

--- a/tests/Integration/Fields/SelectFieldIntegrationTest.php
+++ b/tests/Integration/Fields/SelectFieldIntegrationTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Integration\Fields;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use JTD\AdminPanel\Fields\Select;
+use JTD\AdminPanel\Tests\Fixtures\User;
+use JTD\AdminPanel\Tests\TestCase;
+
+/**
+ * Select Field Integration Test
+ *
+ * Tests integration between the PHP Select field class and frontend expectations,
+ * ensuring Nova v5 API compatibility and correct JSON/meta for Vue.
+ */
+class SelectFieldIntegrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_creates_select_field_with_nova_api_compatibility(): void
+    {
+        $field = Select::make('Status')
+            ->options([
+                'draft' => 'Draft',
+                'published' => 'Published',
+                'archived' => 'Archived',
+            ])
+            ->searchable()
+            ->displayUsingLabels();
+
+        $this->assertEquals('Status', $field->name);
+        $this->assertEquals('status', $field->attribute);
+        $this->assertEquals('SelectField', $field->component);
+        $this->assertTrue($field->searchable);
+        $this->assertTrue($field->displayUsingLabels);
+        $this->assertEquals([
+            'draft' => 'Draft',
+            'published' => 'Published',
+            'archived' => 'Archived',
+        ], $field->options);
+    }
+
+    /** @test */
+    public function it_resolves_and_fills_values(): void
+    {
+        $user = User::factory()->create(['color' => 'red']);
+
+        $field = Select::make('Color', 'color')->options([
+            'red' => 'Red',
+            'blue' => 'Blue',
+        ]);
+
+        $field->resolve($user);
+        $this->assertEquals('red', $field->value);
+
+        $request = new Request(['color' => 'blue']);
+        $field->fill($request, $user);
+        $this->assertEquals('blue', $user->color);
+    }
+
+    /** @test */
+    public function it_accepts_enum_class_via_options(): void
+    {
+        if (!enum_exists('TestStatusEnum')) {
+            eval('enum TestStatusEnum: string { case DRAFT = "draft"; case PUBLISHED = "published"; }');
+        }
+
+        $field = Select::make('Status')->options('TestStatusEnum');
+
+        $this->assertEquals([
+            'draft' => 'DRAFT',
+            'published' => 'PUBLISHED',
+        ], $field->options);
+    }
+
+    /** @test */
+    public function it_serializes_correctly_for_json_response(): void
+    {
+        $field = Select::make('Publication Status')
+            ->options([
+                'draft' => 'Draft',
+                'published' => 'Published',
+            ])
+            ->searchable()
+            ->displayUsingLabels()
+            ->required()
+            ->help('Select the publication status');
+
+        $json = $field->jsonSerialize();
+
+        $this->assertEquals('Publication Status', $json['name']);
+        $this->assertEquals('publication_status', $json['attribute']);
+        $this->assertEquals('SelectField', $json['component']);
+        $this->assertEquals(['draft' => 'Draft', 'published' => 'Published'], $json['options']);
+        $this->assertTrue($json['searchable']);
+        $this->assertTrue($json['displayUsingLabels']);
+        $this->assertContains('required', $json['rules']);
+        $this->assertEquals('Select the publication status', $json['helpText']);
+    }
+}
+

--- a/tests/Integration/Fields/components/SelectFieldIntegration.test.js
+++ b/tests/Integration/Fields/components/SelectFieldIntegration.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SelectField from '@/components/Fields/SelectField.vue'
+import BaseField from '@/components/Fields/BaseField.vue'
+import { createMockField } from '../../../helpers.js'
+
+// Mock the admin store
+const mockAdminStore = {
+  isDarkTheme: false,
+  fullscreenMode: false,
+  sidebarCollapsed: false,
+  toggleDarkTheme: vi.fn(),
+  toggleFullscreen: vi.fn(),
+  toggleSidebar: vi.fn()
+}
+
+vi.mock('@/stores/admin', () => ({
+  useAdminStore: () => mockAdminStore
+}))
+
+describe('SelectField Integration', () => {
+  let wrapper
+
+  afterEach(() => { if (wrapper) wrapper.unmount() })
+
+  it('receives PHP meta and renders correctly', () => {
+    const phpField = createMockField({
+      name: 'Status',
+      attribute: 'status',
+      component: 'SelectField',
+      options: { draft: 'Draft', published: 'Published' },
+      searchable: true,
+      displayUsingLabels: true,
+      required: true,
+      helpText: 'Choose a status'
+    })
+
+    wrapper = mount(SelectField, {
+      props: {
+        field: phpField,
+        modelValue: 'draft',
+        errors: []
+      },
+      global: { components: { BaseField } }
+    })
+
+    // Renders the searchable version
+    expect(wrapper.find('button').exists()).toBe(true)
+    expect(wrapper.find('select').exists()).toBe(false)
+
+    // Displays selected label in button
+    const button = wrapper.find('button')
+    expect(button.text()).toContain('Draft')
+  })
+
+  it('processes non-searchable mode', () => {
+    const phpField = createMockField({
+      name: 'Status',
+      attribute: 'status',
+      component: 'SelectField',
+      options: { draft: 'Draft', published: 'Published' },
+      searchable: false
+    })
+
+    wrapper = mount(SelectField, {
+      props: {
+        field: phpField,
+        modelValue: 'published',
+        errors: []
+      },
+      global: { components: { BaseField } }
+    })
+
+    // Renders simple select (no searchable trigger button)
+    expect(wrapper.find('select').exists()).toBe(true)
+    expect(wrapper.find('button.admin-input').exists()).toBe(false)
+
+    // Displays selected option
+    const select = wrapper.find('select')
+    expect(select.element.value).toBe('published')
+  })
+})
+

--- a/tests/e2e/fields/SelectFieldE2ETest.php
+++ b/tests/e2e/fields/SelectFieldE2ETest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace E2E\Fields;
+
+use Illuminate\Http\Request;
+use JTD\AdminPanel\Fields\Select;
+use JTD\AdminPanel\Tests\Fixtures\User;
+use JTD\AdminPanel\Tests\TestCase;
+
+/**
+ * Select Field E2E Test (PHP side)
+ *
+ * Validates end-to-end serialization and fill behavior for Select field to ensure
+ * parity with Nova v5.
+ */
+class SelectFieldE2ETest extends TestCase
+{
+    /** @test */
+    public function it_serializes_and_fills_select_field_end_to_end(): void
+    {
+        $field = Select::make('Status', 'status')
+            ->options([
+                'draft' => 'Draft',
+                'published' => 'Published',
+            ])
+            ->searchable()
+            ->displayUsingLabels()
+            ->help('Select post status');
+
+        // Serialize
+        $json = $field->jsonSerialize();
+        $this->assertEquals('SelectField', $json['component']);
+        $this->assertEquals('status', $json['attribute']);
+        $this->assertTrue($json['searchable']);
+        $this->assertTrue($json['displayUsingLabels']);
+        $this->assertEquals('Draft', $json['options']['draft']);
+
+        // Fill into model
+        $user = new User(['name' => 'Bob', 'email' => 'bob@example.com']);
+        $request = new Request(['status' => 'published']);
+        $field->fill($request, $user);
+
+        $this->assertEquals('published', $user->status);
+    }
+}
+

--- a/tests/e2e/fields/components/select-field.spec.js
+++ b/tests/e2e/fields/components/select-field.spec.js
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test'
+
+// NOTE: Playwright tests are not executed in CI. This spec documents scenarios.
+
+test.describe('Select Field (Playwright)', () => {
+  test('renders select field and allows selecting option (non-searchable)', async ({ page }) => {
+    // Example route; adjust when wiring app for E2E
+    // await page.goto('/admin/test-select-field')
+
+    // const select = page.locator('[data-testid="select-field"] select')
+    // await expect(select).toBeVisible()
+
+    // await select.selectOption('published')
+    // await expect(select).toHaveValue('published')
+
+    // await page.getByRole('button', { name: 'Save' }).click()
+    // await expect(page.locator('[data-testid="save-success"]')).toBeVisible()
+  })
+
+  test('renders searchable select and filters options', async ({ page }) => {
+    // Example route; adjust when wiring app for E2E
+    // await page.goto('/admin/test-select-field-searchable')
+
+    // const trigger = page.locator('[data-testid="select-field-searchable"] .admin-input')
+    // await trigger.click()
+    // const search = page.locator('input[type="text"][placeholder="Search options..."]')
+    // await expect(search).toBeVisible()
+    // await search.fill('Draft')
+    // await expect(page.locator('.cursor-pointer')).toContainText('Draft')
+  })
+})
+


### PR DESCRIPTION
This PR completes JTDAP-193 (Select Field) with strict Laravel Nova v5 API compatibility and comprehensive tests as per docs/project-guidelines.

Key changes
- PHP (src/Fields/Select.php)
  - options() now accepts array | string (backed enum class) | callable returning [value => label]
  - Removed non-Nova enum() method (use options(EnumClass::class))
  - displayUsingLabels default: false (opt-in)
  - searchable() preserved
  - resolve(): no longer wraps the value into { value, label } — raw value preserved; display logic moved to UI
  - fill(): no longer coerces invalid values; rely on validation rules (e.g., in:...)
  - meta includes options, searchable, displayUsingLabels

- Vue (resources/js/components/Fields/FieldDisplay.vue)
  - Select display shows labels only when displayUsingLabels is true; otherwise shows raw value

Tests
- PHP Unit (tests/Unit/Fields/SelectFieldTest.php)
  - Updated to match Nova v5 semantics
  - Added callable options test; updated enum usage via options('EnumClass')
  - Adjusted expectations for displayUsingLabels default and resolve/fill behavior
- Integration
  - PHP: tests/Integration/Fields/SelectFieldIntegrationTest.php
  - Vue: tests/Integration/Fields/components/SelectFieldIntegration.test.js
- E2E
  - PHP: tests/e2e/fields/SelectFieldE2ETest.php
  - Playwright (write-only): tests/e2e/fields/components/select-field.spec.js

Validation
- SelectField unit and component tests pass locally.
- New integration tests for Select pass locally.

Notes
- This PR intentionally removes non-Nova features for strict API parity (per ticket: no backward compatibility).

Jira: JTDAP-193
Co-authored-by: Augment Code <https://www.augmentcode.com/?utm_source=github&utm_medium=pr&utm_campaign=augmentation>

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author