### PR TITLE
feat(JTDAP-200): Complete Timezone Field Nova API Compatibility

### DIFF
--- a/resources/js/components/Fields/TimezoneField.vue
+++ b/resources/js/components/Fields/TimezoneField.vue
@@ -8,142 +8,30 @@
     :size="size"
     v-bind="$attrs"
   >
-    <div class="relative">
-      <!-- Timezone select dropdown -->
-      <div
-        ref="dropdownRef"
-        class="relative"
+    <select
+      :value="modelValue"
+      class="admin-input w-full"
+      :class="[
+        { 'admin-input-dark': isDarkTheme },
+        { 'border-red-300': hasError },
+        { 'opacity-50 cursor-not-allowed': disabled || readonly }
+      ]"
+      :disabled="disabled || readonly"
+      @change="handleChange"
+      @focus="$emit('focus')"
+      @blur="$emit('blur')"
+    >
+      <option value="">
+        {{ field.placeholder || 'Select timezone...' }}
+      </option>
+      <option
+        v-for="(label, value) in options"
+        :key="value"
+        :value="value"
       >
-        <!-- Selected timezone display / Search input -->
-        <div
-          class="admin-input min-h-[2.5rem] p-2 cursor-pointer flex items-center justify-between"
-          :class="[
-            { 'admin-input-dark': isDarkTheme },
-            { 'border-red-300': hasError },
-            { 'opacity-50 cursor-not-allowed': disabled || readonly }
-          ]"
-          @click="toggleDropdown"
-        >
-          <!-- Selected timezone or search input -->
-          <div class="flex-1">
-            <input
-              v-if="field.searchable && isOpen"
-              ref="searchInputRef"
-              v-model="searchQuery"
-              type="text"
-              class="w-full border-none outline-none bg-transparent text-sm"
-              :placeholder="selectedTimezone ? selectedTimezone : 'Search timezones...'"
-              @click.stop
-              @keydown="handleKeydown"
-            />
-            <span
-              v-else
-              class="text-sm"
-              :class="{ 'text-gray-500': !modelValue, 'text-gray-400': !modelValue && isDarkTheme }"
-            >
-              {{ selectedTimezone || field.placeholder || 'Select timezone...' }}
-            </span>
-          </div>
-
-          <!-- Dropdown arrow -->
-          <ChevronDownIcon
-            class="w-5 h-5 text-gray-400 transition-transform duration-200 ml-2"
-            :class="{ 'transform rotate-180': isOpen }"
-          />
-        </div>
-
-        <!-- Dropdown menu -->
-        <Transition
-          enter-active-class="transition ease-out duration-100"
-          enter-from-class="transform opacity-0 scale-95"
-          enter-to-class="transform opacity-100 scale-100"
-          leave-active-class="transition ease-in duration-75"
-          leave-from-class="transform opacity-100 scale-100"
-          leave-to-class="transform opacity-0 scale-95"
-        >
-          <div
-            v-if="isOpen"
-            class="absolute z-10 mt-1 w-full bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-auto"
-            :class="{ 'bg-gray-800 border-gray-600': isDarkTheme }"
-          >
-            <!-- No results message -->
-            <div
-              v-if="filteredTimezones.length === 0"
-              class="px-3 py-2 text-sm text-gray-500"
-              :class="{ 'text-gray-400': isDarkTheme }"
-            >
-              No timezones found
-            </div>
-
-            <!-- Grouped timezones -->
-            <template v-if="field.groupByRegion && !field.searchable">
-              <div
-                v-for="(timezones, region) in filteredTimezones"
-                :key="region"
-                class="border-b border-gray-100 last:border-b-0"
-                :class="{ 'border-gray-700': isDarkTheme }"
-              >
-                <div
-                  class="px-3 py-1 text-xs font-semibold text-gray-600 bg-gray-50 sticky top-0"
-                  :class="{ 'text-gray-300 bg-gray-700': isDarkTheme }"
-                >
-                  {{ region }}
-                </div>
-                <div
-                  v-for="(name, identifier) in timezones"
-                  :key="identifier"
-                  class="px-3 py-2 text-sm cursor-pointer hover:bg-gray-100 flex items-center justify-between"
-                  :class="[
-                    { 'hover:bg-gray-700': isDarkTheme },
-                    { 'bg-blue-50 text-blue-700': isSelected(identifier) && !isDarkTheme },
-                    { 'bg-blue-900 text-blue-200': isSelected(identifier) && isDarkTheme }
-                  ]"
-                  @click="selectTimezone(identifier)"
-                >
-                  <span>{{ name }}</span>
-                  <CheckIcon
-                    v-if="isSelected(identifier)"
-                    class="w-4 h-4 text-blue-600"
-                    :class="{ 'text-blue-400': isDarkTheme }"
-                  />
-                </div>
-              </div>
-            </template>
-
-            <!-- Flat timezone list -->
-            <template v-else>
-              <div
-                v-for="(name, identifier) in filteredTimezones"
-                :key="identifier"
-                class="px-3 py-2 text-sm cursor-pointer hover:bg-gray-100 flex items-center justify-between"
-                :class="[
-                  { 'hover:bg-gray-700': isDarkTheme },
-                  { 'bg-blue-50 text-blue-700': isSelected(identifier) && !isDarkTheme },
-                  { 'bg-blue-900 text-blue-200': isSelected(identifier) && isDarkTheme }
-                ]"
-                @click="selectTimezone(identifier)"
-              >
-                <span>{{ name }}</span>
-                <CheckIcon
-                  v-if="isSelected(identifier)"
-                  class="w-4 h-4 text-blue-600"
-                  :class="{ 'text-blue-400': isDarkTheme }"
-                />
-              </div>
-            </template>
-          </div>
-        </Transition>
-      </div>
-
-      <!-- Current time display -->
-      <div
-        v-if="modelValue && showCurrentTime"
-        class="mt-2 text-xs text-gray-500"
-        :class="{ 'text-gray-400': isDarkTheme }"
-      >
-        Current time: {{ currentTime }}
-      </div>
-    </div>
+        {{ label }}
+      </option>
+    </select>
   </BaseField>
 </template>
 
@@ -151,15 +39,14 @@
 /**
  * TimezoneField Component
  *
- * Timezone selection dropdown with searchable options and regional grouping.
- * Supports common timezones filtering and displays current time in selected timezone.
+ * A simple timezone selection field. Generates a Select field containing
+ * a list of the world's timezones.
  *
  * @author Jeremy Fall <jerthedev@gmail.com>
  */
 
-import { ref, computed, nextTick, onMounted, onUnmounted, watch } from 'vue'
+import { computed } from 'vue'
 import { useAdminStore } from '@/stores/admin'
-import { ChevronDownIcon, CheckIcon } from '@heroicons/vue/24/outline'
 import BaseField from './BaseField.vue'
 
 // Props
@@ -169,12 +56,12 @@ const props = defineProps({
     required: true
   },
   modelValue: {
-    type: String,
-    default: ''
+    type: [String, null],
+    default: null
   },
   errors: {
-    type: Object,
-    default: () => ({})
+    type: Array,
+    default: () => []
   },
   disabled: {
     type: Boolean,
@@ -186,208 +73,29 @@ const props = defineProps({
   },
   size: {
     type: String,
-    default: 'default'
+    default: 'md'
   }
 })
 
 // Emits
-const emit = defineEmits(['update:modelValue', 'focus', 'blur', 'change'])
-
-// Refs
-const dropdownRef = ref(null)
-const searchInputRef = ref(null)
-const isOpen = ref(false)
-const searchQuery = ref('')
-const currentTime = ref('')
-const timeInterval = ref(null)
+const emit = defineEmits(['update:modelValue', 'focus', 'blur'])
 
 // Store
 const adminStore = useAdminStore()
 
-// Computed
+// Computed properties
 const isDarkTheme = computed(() => adminStore.isDarkTheme)
 
-const hasError = computed(() => {
-  return props.errors && Object.keys(props.errors).length > 0
-})
+const hasError = computed(() => props.errors.length > 0)
 
-const timezones = computed(() => {
-  return props.field.timezones || {}
-})
-
-const selectedTimezone = computed(() => {
-  if (!props.modelValue) return ''
-
-  if (props.field.groupByRegion) {
-    // Find in grouped timezones
-    for (const region in timezones.value) {
-      if (timezones.value[region][props.modelValue]) {
-        return timezones.value[region][props.modelValue]
-      }
-    }
-  } else {
-    return timezones.value[props.modelValue] || props.modelValue
-  }
-
-  return props.modelValue
-})
-
-const filteredTimezones = computed(() => {
-  if (!props.field.searchable || !searchQuery.value) {
-    return timezones.value
-  }
-
-  const query = searchQuery.value.toLowerCase()
-
-  if (props.field.groupByRegion) {
-    const filtered = {}
-    for (const [region, regionTimezones] of Object.entries(timezones.value)) {
-      const filteredRegion = {}
-      for (const [identifier, name] of Object.entries(regionTimezones)) {
-        if (
-          name.toLowerCase().includes(query) ||
-          identifier.toLowerCase().includes(query) ||
-          region.toLowerCase().includes(query)
-        ) {
-          filteredRegion[identifier] = name
-        }
-      }
-      if (Object.keys(filteredRegion).length > 0) {
-        filtered[region] = filteredRegion
-      }
-    }
-    return filtered
-  } else {
-    const filtered = {}
-    for (const [identifier, name] of Object.entries(timezones.value)) {
-      if (
-        name.toLowerCase().includes(query) ||
-        identifier.toLowerCase().includes(query)
-      ) {
-        filtered[identifier] = name
-      }
-    }
-    return filtered
-  }
-})
-
-const showCurrentTime = computed(() => {
-  return props.modelValue && !props.readonly && !props.disabled
+const options = computed(() => {
+  return props.field.options || {}
 })
 
 // Methods
-const isSelected = (identifier) => {
-  return props.modelValue === identifier
+const handleChange = (event) => {
+  emit('update:modelValue', event.target.value || null)
 }
-
-const toggleDropdown = () => {
-  if (props.disabled || props.readonly) return
-
-  isOpen.value = !isOpen.value
-
-  if (isOpen.value && props.field.searchable) {
-    nextTick(() => {
-      searchInputRef.value?.focus()
-    })
-  }
-}
-
-const selectTimezone = (identifier) => {
-  if (props.disabled || props.readonly) return
-
-  emit('update:modelValue', identifier)
-  emit('change', identifier)
-
-  isOpen.value = false
-  searchQuery.value = ''
-
-  updateCurrentTime()
-}
-
-const handleKeydown = (event) => {
-  if (event.key === 'Escape') {
-    isOpen.value = false
-    searchQuery.value = ''
-  }
-}
-
-const handleClickOutside = (event) => {
-  if (dropdownRef.value && !dropdownRef.value.contains(event.target)) {
-    isOpen.value = false
-    searchQuery.value = ''
-  }
-}
-
-const updateCurrentTime = () => {
-  if (!props.modelValue) {
-    currentTime.value = ''
-    return
-  }
-
-  try {
-    const now = new Date()
-    const formatter = new Intl.DateTimeFormat('en-US', {
-      timeZone: props.modelValue,
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-      hour12: true
-    })
-    currentTime.value = formatter.format(now)
-  } catch (error) {
-    currentTime.value = 'Invalid timezone'
-  }
-}
-
-// Lifecycle
-onMounted(() => {
-  document.addEventListener('click', handleClickOutside)
-
-  if (props.modelValue) {
-    updateCurrentTime()
-    // Update time every second
-    timeInterval.value = setInterval(updateCurrentTime, 1000)
-  }
-})
-
-onUnmounted(() => {
-  document.removeEventListener('click', handleClickOutside)
-  if (timeInterval.value) {
-    clearInterval(timeInterval.value)
-  }
-})
-
-// Watch for timezone changes
-watch(() => props.modelValue, (newValue) => {
-  if (newValue) {
-    updateCurrentTime()
-    if (!timeInterval.value) {
-      timeInterval.value = setInterval(updateCurrentTime, 1000)
-    }
-  } else {
-    currentTime.value = ''
-    if (timeInterval.value) {
-      clearInterval(timeInterval.value)
-      timeInterval.value = null
-    }
-  }
-})
 </script>
 
-<style scoped>
-/* Ensure proper z-index for dropdown */
-.z-10 {
-  z-index: 10;
-}
 
-/* Smooth transitions */
-.transition {
-  transition-property: all;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-/* Sticky region headers */
-.sticky {
-  position: sticky;
-}
-</style>

--- a/src/Fields/Timezone.php
+++ b/src/Fields/Timezone.php
@@ -9,8 +9,8 @@ use DateTimeZone;
 /**
  * Timezone Field.
  *
- * A field for selecting timezones with searchable dropdown and regional grouping.
- * Supports common timezones filtering and timezone grouping by region.
+ * A field for selecting timezones. Generates a Select field containing
+ * a list of the world's timezones.
  *
  * @author Jeremy Fall <jerthedev@gmail.com>
  */
@@ -22,163 +22,30 @@ class Timezone extends Field
     public string $component = 'TimezoneField';
 
     /**
-     * Whether the timezone field should be searchable.
-     */
-    public bool $searchable = true;
-
-    /**
-     * Whether to group timezones by region.
-     */
-    public bool $groupByRegion = false;
-
-    /**
-     * Whether to show only common timezones.
-     */
-    public bool $onlyCommon = false;
-
-    /**
-     * Common timezones that are frequently used.
-     */
-    protected array $commonTimezones = [
-        'UTC' => 'UTC',
-        'America/New_York' => 'Eastern Time (US & Canada)',
-        'America/Chicago' => 'Central Time (US & Canada)',
-        'America/Denver' => 'Mountain Time (US & Canada)',
-        'America/Los_Angeles' => 'Pacific Time (US & Canada)',
-        'America/Anchorage' => 'Alaska',
-        'Pacific/Honolulu' => 'Hawaii',
-        'Europe/London' => 'London',
-        'Europe/Paris' => 'Paris',
-        'Europe/Berlin' => 'Berlin',
-        'Europe/Rome' => 'Rome',
-        'Europe/Madrid' => 'Madrid',
-        'Europe/Amsterdam' => 'Amsterdam',
-        'Europe/Stockholm' => 'Stockholm',
-        'Europe/Moscow' => 'Moscow',
-        'Asia/Tokyo' => 'Tokyo',
-        'Asia/Shanghai' => 'Beijing',
-        'Asia/Hong_Kong' => 'Hong Kong',
-        'Asia/Singapore' => 'Singapore',
-        'Asia/Seoul' => 'Seoul',
-        'Asia/Kolkata' => 'Mumbai',
-        'Asia/Dubai' => 'Dubai',
-        'Australia/Sydney' => 'Sydney',
-        'Australia/Melbourne' => 'Melbourne',
-        'Australia/Perth' => 'Perth',
-        'Pacific/Auckland' => 'Auckland',
-    ];
-
-    /**
-     * Make the timezone field searchable.
-     */
-    public function searchable(bool $searchable = true): static
-    {
-        $this->searchable = $searchable;
-
-        return $this;
-    }
-
-    /**
-     * Group timezones by region.
-     */
-    public function groupByRegion(bool $groupByRegion = true): static
-    {
-        $this->groupByRegion = $groupByRegion;
-
-        return $this;
-    }
-
-    /**
-     * Show only common timezones.
-     */
-    public function onlyCommon(bool $onlyCommon = true): static
-    {
-        $this->onlyCommon = $onlyCommon;
-
-        return $this;
-    }
-
-    /**
-     * Get the list of timezones.
-     */
-    public function getTimezones(): array
-    {
-        if ($this->onlyCommon) {
-            return $this->commonTimezones;
-        }
-
-        $timezones = [];
-        $identifiers = DateTimeZone::listIdentifiers();
-
-        foreach ($identifiers as $identifier) {
-            // Skip deprecated timezones
-            if (strpos($identifier, '/') === false) {
-                continue;
-            }
-
-            // Create a human-readable name
-            $name = str_replace('_', ' ', $identifier);
-            $parts = explode('/', $name);
-
-            if (count($parts) >= 2) {
-                $region = $parts[0];
-                $city = $parts[1];
-
-                if (count($parts) > 2) {
-                    $city .= ' - '.$parts[2];
-                }
-
-                $name = $city.' ('.$region.')';
-            }
-
-            $timezones[$identifier] = $name;
-        }
-
-        // Sort by display name
-        asort($timezones);
-
-        return $timezones;
-    }
-
-    /**
-     * Get timezones grouped by region.
-     */
-    public function getTimezonesGrouped(): array
-    {
-        $timezones = $this->getTimezones();
-        $grouped = [];
-
-        foreach ($timezones as $identifier => $name) {
-            $parts = explode('/', $identifier);
-            $region = $parts[0] ?? 'Other';
-
-            if (! isset($grouped[$region])) {
-                $grouped[$region] = [];
-            }
-
-            $grouped[$region][$identifier] = $name;
-        }
-
-        // Sort regions
-        ksort($grouped);
-
-        return $grouped;
-    }
-
-    /**
      * Get additional meta information to merge with the field payload.
      */
     public function meta(): array
     {
-        $timezones = $this->groupByRegion
-            ? $this->getTimezonesGrouped()
-            : $this->getTimezones();
-
         return array_merge(parent::meta(), [
-            'searchable' => $this->searchable,
-            'groupByRegion' => $this->groupByRegion,
-            'onlyCommon' => $this->onlyCommon,
-            'timezones' => $timezones,
+            'options' => $this->getTimezoneOptions(),
         ]);
+    }
+
+    /**
+     * Get the timezone options for the select field.
+     */
+    protected function getTimezoneOptions(): array
+    {
+        $timezones = [];
+        $identifiers = DateTimeZone::listIdentifiers();
+
+        foreach ($identifiers as $identifier) {
+            $timezones[$identifier] = $identifier;
+        }
+
+        // Sort alphabetically
+        asort($timezones);
+
+        return $timezones;
     }
 }

--- a/tests/Integration/Fields/TimezoneFieldIntegrationTest.php
+++ b/tests/Integration/Fields/TimezoneFieldIntegrationTest.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Integration\Fields;
+
+use DateTimeZone;
+use Illuminate\Http\Request;
+use JTD\AdminPanel\Fields\Timezone;
+use JTD\AdminPanel\Tests\TestCase;
+
+/**
+ * Timezone Field Integration Tests
+ *
+ * Tests the complete integration between PHP backend and frontend
+ * for the Timezone field, ensuring Nova API compatibility.
+ *
+ * @author Jeremy Fall <jerthedev@gmail.com>
+ */
+class TimezoneFieldIntegrationTest extends TestCase
+{
+    /** @test */
+    public function it_creates_timezone_field_with_nova_api(): void
+    {
+        $field = Timezone::make('User Timezone');
+
+        $this->assertEquals('User Timezone', $field->name);
+        $this->assertEquals('user_timezone', $field->attribute);
+        $this->assertEquals('TimezoneField', $field->component);
+    }
+
+    /** @test */
+    public function it_creates_timezone_field_with_custom_attribute(): void
+    {
+        $field = Timezone::make('Timezone', 'custom_timezone');
+
+        $this->assertEquals('Timezone', $field->name);
+        $this->assertEquals('custom_timezone', $field->attribute);
+    }
+
+    /** @test */
+    public function it_serializes_timezone_field_for_frontend(): void
+    {
+        $field = Timezone::make('User Timezone')
+            ->required()
+            ->help('Select your timezone')
+            ->placeholder('Choose timezone...');
+
+        $json = $field->jsonSerialize();
+
+        $this->assertEquals('User Timezone', $json['name']);
+        $this->assertEquals('user_timezone', $json['attribute']);
+        $this->assertEquals('TimezoneField', $json['component']);
+        $this->assertArrayHasKey('options', $json);
+        $this->assertIsArray($json['options']);
+        $this->assertNotEmpty($json['options']);
+        $this->assertContains('required', $json['rules']);
+        $this->assertEquals('Select your timezone', $json['helpText']);
+        $this->assertEquals('Choose timezone...', $json['placeholder']);
+    }
+
+    /** @test */
+    public function it_includes_all_php_timezones_in_options(): void
+    {
+        $field = Timezone::make('Timezone');
+        $json = $field->jsonSerialize();
+
+        $phpTimezones = DateTimeZone::listIdentifiers();
+        $fieldOptions = $json['options'];
+
+        // Should include all PHP timezones
+        foreach ($phpTimezones as $timezone) {
+            $this->assertArrayHasKey($timezone, $fieldOptions);
+            $this->assertEquals($timezone, $fieldOptions[$timezone]);
+        }
+
+        // Should have same count as PHP timezones
+        $this->assertCount(count($phpTimezones), $fieldOptions);
+    }
+
+    /** @test */
+    public function it_includes_common_timezones(): void
+    {
+        $field = Timezone::make('Timezone');
+        $json = $field->jsonSerialize();
+
+        $commonTimezones = [
+            'UTC',
+            'America/New_York',
+            'America/Chicago',
+            'America/Denver',
+            'America/Los_Angeles',
+            'Europe/London',
+            'Europe/Paris',
+            'Asia/Tokyo',
+            'Australia/Sydney',
+        ];
+
+        foreach ($commonTimezones as $timezone) {
+            $this->assertArrayHasKey($timezone, $json['options']);
+            $this->assertEquals($timezone, $json['options'][$timezone]);
+        }
+    }
+
+    /** @test */
+    public function it_resolves_timezone_value_from_model(): void
+    {
+        $field = Timezone::make('Timezone');
+        $resource = (object) ['timezone' => 'America/New_York'];
+
+        $field->resolve($resource);
+
+        $this->assertEquals('America/New_York', $field->value);
+    }
+
+    /** @test */
+    public function it_resolves_null_timezone_value(): void
+    {
+        $field = Timezone::make('Timezone');
+        $resource = (object) ['timezone' => null];
+
+        $field->resolve($resource);
+
+        $this->assertNull($field->value);
+    }
+
+    /** @test */
+    public function it_fills_timezone_value_into_model(): void
+    {
+        $field = Timezone::make('Timezone');
+        $model = new \stdClass();
+        $request = new Request(['timezone' => 'America/New_York']);
+
+        $field->fill($request, $model);
+
+        $this->assertEquals('America/New_York', $model->timezone);
+    }
+
+    /** @test */
+    public function it_fills_empty_timezone_value(): void
+    {
+        $field = Timezone::make('Timezone');
+        $model = new \stdClass();
+        $request = new Request(['timezone' => '']);
+
+        $field->fill($request, $model);
+
+        $this->assertEquals('', $model->timezone);
+    }
+
+    /** @test */
+    public function it_fills_null_timezone_value(): void
+    {
+        $field = Timezone::make('Timezone');
+        $model = new \stdClass();
+        $request = new Request(['timezone' => null]);
+
+        $field->fill($request, $model);
+
+        $this->assertNull($model->timezone);
+    }
+
+    /** @test */
+    public function it_supports_nova_api_method_chaining(): void
+    {
+        $field = Timezone::make('User Timezone')
+            ->required()
+            ->nullable()
+            ->help('Select your timezone')
+            ->placeholder('Choose timezone...')
+            ->sortable()
+            ->hideFromIndex()
+            ->showOnDetail();
+
+        $this->assertInstanceOf(Timezone::class, $field);
+        $this->assertEquals('User Timezone', $field->name);
+        $this->assertEquals('user_timezone', $field->attribute);
+        $this->assertEquals('TimezoneField', $field->component);
+    }
+
+    /** @test */
+    public function it_supports_nova_validation_rules(): void
+    {
+        $field = Timezone::make('Timezone')
+            ->rules('required', 'timezone')
+            ->nullable();
+
+        $json = $field->jsonSerialize();
+
+        $this->assertContains('required', $json['rules']);
+        $this->assertContains('timezone', $json['rules']);
+        $this->assertTrue($json['nullable']);
+    }
+
+    /** @test */
+    public function it_supports_nova_default_values(): void
+    {
+        $field = Timezone::make('Timezone')->default('UTC');
+
+        $json = $field->jsonSerialize();
+
+        $this->assertEquals('UTC', $json['default']);
+    }
+
+    /** @test */
+    public function it_supports_nova_default_callback(): void
+    {
+        $field = Timezone::make('Timezone')->default(function () {
+            return 'America/New_York';
+        });
+
+        $json = $field->jsonSerialize();
+
+        $this->assertIsCallable($json['default']);
+    }
+
+    /** @test */
+    public function it_integrates_complete_nova_api_workflow(): void
+    {
+        // 1. Create field with Nova API
+        $field = Timezone::make('User Timezone')
+            ->required()
+            ->help('Select your timezone');
+
+        // 2. Serialize for frontend
+        $serialized = $field->jsonSerialize();
+        $this->assertEquals('TimezoneField', $serialized['component']);
+        $this->assertArrayHasKey('options', $serialized);
+        $this->assertIsArray($serialized['options']);
+
+        // 3. Fill from request
+        $model = new \stdClass();
+        $request = new Request(['user_timezone' => 'America/New_York']);
+        $field->fill($request, $model);
+        $this->assertEquals('America/New_York', $model->user_timezone);
+
+        // 4. Resolve for display
+        $resource = (object) ['user_timezone' => 'America/New_York'];
+        $field->resolve($resource);
+        $this->assertEquals('America/New_York', $field->value);
+    }
+
+    /** @test */
+    public function it_handles_edge_case_timezones(): void
+    {
+        $field = Timezone::make('Timezone');
+        $json = $field->jsonSerialize();
+
+        // Test edge case timezones
+        $edgeCases = [
+            'UTC',
+            'GMT',
+            'America/Argentina/Buenos_Aires',
+            'Pacific/Kiritimati',
+            'Antarctica/McMurdo',
+        ];
+
+        foreach ($edgeCases as $timezone) {
+            if (in_array($timezone, DateTimeZone::listIdentifiers())) {
+                $this->assertArrayHasKey($timezone, $json['options']);
+                $this->assertEquals($timezone, $json['options'][$timezone]);
+            }
+        }
+    }
+
+    /** @test */
+    public function it_maintains_timezone_options_sorting(): void
+    {
+        $field = Timezone::make('Timezone');
+        $json = $field->jsonSerialize();
+
+        $options = $json['options'];
+        $sortedOptions = $options;
+        asort($sortedOptions);
+
+        $this->assertEquals($sortedOptions, $options);
+    }
+
+    /** @test */
+    public function it_validates_timezone_identifiers(): void
+    {
+        $field = Timezone::make('Timezone');
+        $json = $field->jsonSerialize();
+
+        // All options should be valid timezone identifiers
+        foreach (array_keys($json['options']) as $timezone) {
+            $this->assertContains($timezone, DateTimeZone::listIdentifiers());
+        }
+    }
+
+    /** @test */
+    public function it_handles_fill_with_custom_callback(): void
+    {
+        $field = Timezone::make('Timezone')->fillUsing(function ($request, $model, $attribute) {
+            $model->{$attribute} = 'UTC';
+        });
+
+        $model = new \stdClass();
+        $request = new Request(['timezone' => 'America/New_York']);
+
+        $field->fill($request, $model);
+
+        $this->assertEquals('UTC', $model->timezone);
+    }
+
+    /** @test */
+    public function it_ensures_nova_api_compatibility(): void
+    {
+        $field = Timezone::make('Timezone');
+        $json = $field->jsonSerialize();
+
+        // Should use 'options' key for Nova compatibility
+        $this->assertArrayHasKey('options', $json);
+
+        // Should NOT have custom properties from old implementation
+        $this->assertArrayNotHasKey('timezones', $json);
+        $this->assertArrayNotHasKey('groupByRegion', $json);
+        $this->assertArrayNotHasKey('onlyCommon', $json);
+
+        // Should have standard Nova field properties
+        $this->assertArrayHasKey('searchable', $json);
+        $this->assertArrayHasKey('sortable', $json);
+        $this->assertArrayHasKey('nullable', $json);
+        $this->assertFalse($json['searchable']); // Default value
+
+        // Options should be simple key-value pairs
+        foreach ($json['options'] as $key => $value) {
+            $this->assertEquals($key, $value);
+            $this->assertIsString($key);
+            $this->assertIsString($value);
+        }
+    }
+}

--- a/tests/Integration/Fields/components/TimezoneFieldIntegration.test.js
+++ b/tests/Integration/Fields/components/TimezoneFieldIntegration.test.js
@@ -1,0 +1,490 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import TimezoneField from '@/components/Fields/TimezoneField.vue'
+import { createMockField } from '../../../helpers.js'
+
+// Mock the admin store
+const mockAdminStore = {
+  isDarkTheme: false
+}
+
+vi.mock('@/stores/admin', () => ({
+  useAdminStore: () => mockAdminStore
+}))
+
+// Mock BaseField component
+vi.mock('@/components/Fields/BaseField.vue', () => ({
+  default: {
+    name: 'BaseField',
+    template: '<div class="base-field" data-testid="base-field"><slot /></div>',
+    props: ['field', 'modelValue', 'errors', 'disabled', 'readonly', 'size']
+  }
+}))
+
+describe('TimezoneField Integration', () => {
+  let wrapper
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount()
+    }
+  })
+
+  describe('PHP to Vue Integration', () => {
+    it('receives and processes PHP field configuration correctly', async () => {
+      const phpFieldConfig = createMockField({
+        name: 'User Timezone',
+        attribute: 'user_timezone',
+        component: 'TimezoneField',
+        placeholder: 'Select your timezone...',
+        rules: ['required'],
+        helpText: 'Choose your timezone',
+        options: {
+          'UTC': 'UTC',
+          'America/New_York': 'America/New_York',
+          'America/Chicago': 'America/Chicago',
+          'America/Denver': 'America/Denver',
+          'America/Los_Angeles': 'America/Los_Angeles',
+          'Europe/London': 'Europe/London',
+          'Europe/Paris': 'Europe/Paris',
+          'Asia/Tokyo': 'Asia/Tokyo',
+          'Australia/Sydney': 'Australia/Sydney'
+        }
+      })
+
+      wrapper = mount(TimezoneField, {
+        props: {
+          field: phpFieldConfig,
+          modelValue: 'America/New_York'
+        }
+      })
+
+      // Should render base field wrapper
+      expect(wrapper.find('[data-testid="base-field"]').exists()).toBe(true)
+
+      // Should render select element
+      const select = wrapper.find('select')
+      expect(select.exists()).toBe(true)
+      expect(select.element.value).toBe('America/New_York')
+
+      // Should have all timezone options
+      const options = wrapper.findAll('option')
+      expect(options.length).toBe(Object.keys(phpFieldConfig.options).length + 1) // +1 for placeholder
+
+      // Should display placeholder
+      const placeholder = wrapper.find('option[value=""]')
+      expect(placeholder.text()).toBe('Select your timezone...')
+    })
+
+    it('processes PHP timezone options correctly', () => {
+      const phpFieldConfig = createMockField({
+        name: 'Timezone',
+        attribute: 'timezone',
+        component: 'TimezoneField',
+        options: {
+          'UTC': 'UTC',
+          'America/New_York': 'America/New_York',
+          'Europe/London': 'Europe/London',
+          'Asia/Tokyo': 'Asia/Tokyo'
+        }
+      })
+
+      wrapper = mount(TimezoneField, {
+        props: {
+          field: phpFieldConfig,
+          modelValue: null
+        }
+      })
+
+      // Should process options correctly
+      expect(wrapper.vm.options).toEqual(phpFieldConfig.options)
+
+      // Each timezone should appear as both key and value
+      Object.entries(phpFieldConfig.options).forEach(([key, value]) => {
+        expect(key).toBe(value)
+        const option = wrapper.find(`option[value="${key}"]`)
+        expect(option.exists()).toBe(true)
+        expect(option.text()).toBe(value)
+      })
+    })
+
+    it('handles empty options from PHP gracefully', () => {
+      const phpFieldConfig = createMockField({
+        name: 'Timezone',
+        attribute: 'timezone',
+        component: 'TimezoneField',
+        options: {}
+      })
+
+      wrapper = mount(TimezoneField, {
+        props: {
+          field: phpFieldConfig,
+          modelValue: null
+        }
+      })
+
+      expect(wrapper.vm.options).toEqual({})
+      
+      // Should only have placeholder option
+      const options = wrapper.findAll('option')
+      expect(options.length).toBe(1)
+      expect(options[0].attributes('value')).toBe('')
+    })
+
+    it('handles missing options from PHP gracefully', () => {
+      const phpFieldConfig = createMockField({
+        name: 'Timezone',
+        attribute: 'timezone',
+        component: 'TimezoneField'
+        // No options property
+      })
+
+      wrapper = mount(TimezoneField, {
+        props: {
+          field: phpFieldConfig,
+          modelValue: null
+        }
+      })
+
+      expect(wrapper.vm.options).toEqual({})
+    })
+  })
+
+  describe('Vue to PHP Integration', () => {
+    it('emits timezone selection for PHP processing', async () => {
+      const phpFieldConfig = createMockField({
+        name: 'Timezone',
+        attribute: 'timezone',
+        component: 'TimezoneField',
+        options: {
+          'UTC': 'UTC',
+          'America/New_York': 'America/New_York',
+          'Europe/London': 'Europe/London'
+        }
+      })
+
+      wrapper = mount(TimezoneField, {
+        props: {
+          field: phpFieldConfig,
+          modelValue: null
+        }
+      })
+
+      const select = wrapper.find('select')
+      await select.setValue('America/New_York')
+
+      // Should emit value that PHP can process
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+      expect(wrapper.emitted('update:modelValue')[0][0]).toBe('America/New_York')
+    })
+
+    it('emits null for empty selection', async () => {
+      const phpFieldConfig = createMockField({
+        name: 'Timezone',
+        attribute: 'timezone',
+        component: 'TimezoneField',
+        options: {
+          'UTC': 'UTC',
+          'America/New_York': 'America/New_York'
+        }
+      })
+
+      wrapper = mount(TimezoneField, {
+        props: {
+          field: phpFieldConfig,
+          modelValue: 'America/New_York'
+        }
+      })
+
+      const select = wrapper.find('select')
+      await select.setValue('')
+
+      // Should emit null for PHP to handle as empty value
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+      expect(wrapper.emitted('update:modelValue')[0][0]).toBe(null)
+    })
+
+    it('handles timezone validation errors from PHP', async () => {
+      const phpFieldConfig = createMockField({
+        name: 'Timezone',
+        attribute: 'timezone',
+        component: 'TimezoneField',
+        options: {
+          'UTC': 'UTC',
+          'America/New_York': 'America/New_York'
+        }
+      })
+
+      wrapper = mount(TimezoneField, {
+        props: {
+          field: phpFieldConfig,
+          modelValue: null,
+          errors: ['The timezone field is required.']
+        }
+      })
+
+      // Should apply error styling
+      const select = wrapper.find('select')
+      expect(select.classes()).toContain('border-red-300')
+    })
+  })
+
+  describe('Nova API Compatibility Integration', () => {
+    it('integrates all Nova API methods correctly', async () => {
+      const phpFieldConfig = createMockField({
+        name: 'User Timezone',
+        attribute: 'user_timezone',
+        component: 'TimezoneField',
+        placeholder: 'Choose your timezone',
+        rules: ['required', 'timezone'],
+        helpText: 'Select your timezone',
+        nullable: false,
+        sortable: true,
+        options: {
+          'UTC': 'UTC',
+          'America/New_York': 'America/New_York',
+          'Europe/London': 'Europe/London',
+          'Asia/Tokyo': 'Asia/Tokyo'
+        }
+      })
+
+      wrapper = mount(TimezoneField, {
+        props: {
+          field: phpFieldConfig,
+          modelValue: 'America/New_York'
+        }
+      })
+
+      // Should handle all Nova field properties
+      expect(wrapper.vm.field.name).toBe('User Timezone')
+      expect(wrapper.vm.field.attribute).toBe('user_timezone')
+      expect(wrapper.vm.field.component).toBe('TimezoneField')
+      expect(wrapper.vm.field.placeholder).toBe('Choose your timezone')
+      expect(wrapper.vm.field.helpText).toBe('Select your timezone')
+      expect(wrapper.vm.field.options).toEqual(phpFieldConfig.options)
+
+      // Should display selected value
+      const select = wrapper.find('select')
+      expect(select.element.value).toBe('America/New_York')
+    })
+
+    it('uses Nova standard field structure', () => {
+      const phpFieldConfig = createMockField({
+        name: 'Timezone',
+        attribute: 'timezone',
+        component: 'TimezoneField',
+        options: {
+          'UTC': 'UTC',
+          'America/New_York': 'America/New_York'
+        }
+      })
+
+      wrapper = mount(TimezoneField, {
+        props: {
+          field: phpFieldConfig,
+          modelValue: null
+        }
+      })
+
+      // Should use 'options' not custom properties
+      expect(wrapper.vm.options).toEqual(phpFieldConfig.options)
+      expect(wrapper.vm.field.options).toBeDefined()
+      
+      // Should NOT have custom properties from old implementation
+      expect(wrapper.vm.field.timezones).toBeUndefined()
+      expect(wrapper.vm.field.searchable).toBeUndefined()
+      expect(wrapper.vm.field.groupByRegion).toBeUndefined()
+      expect(wrapper.vm.field.onlyCommon).toBeUndefined()
+    })
+
+    it('emits only Nova standard events', async () => {
+      const phpFieldConfig = createMockField({
+        name: 'Timezone',
+        attribute: 'timezone',
+        component: 'TimezoneField',
+        options: {
+          'UTC': 'UTC',
+          'America/New_York': 'America/New_York'
+        }
+      })
+
+      wrapper = mount(TimezoneField, {
+        props: {
+          field: phpFieldConfig,
+          modelValue: null
+        }
+      })
+
+      const select = wrapper.find('select')
+      await select.trigger('focus')
+      await select.trigger('blur')
+
+      // Should emit Nova standard events
+      expect(wrapper.emitted('focus')).toBeTruthy()
+      expect(wrapper.emitted('blur')).toBeTruthy()
+
+      // Should NOT emit custom events beyond Nova's API
+      expect(wrapper.emitted('search')).toBeFalsy()
+      expect(wrapper.emitted('toggle')).toBeFalsy()
+      expect(wrapper.emitted('open')).toBeFalsy()
+      expect(wrapper.emitted('close')).toBeFalsy()
+    })
+  })
+
+  describe('CRUD Operations Integration', () => {
+    it('handles create operation with timezone field', async () => {
+      const phpFieldConfig = createMockField({
+        name: 'Timezone',
+        attribute: 'timezone',
+        component: 'TimezoneField',
+        options: {
+          'UTC': 'UTC',
+          'America/New_York': 'America/New_York',
+          'Europe/London': 'Europe/London'
+        }
+      })
+
+      wrapper = mount(TimezoneField, {
+        props: {
+          field: phpFieldConfig,
+          modelValue: null // New record
+        }
+      })
+
+      const select = wrapper.find('select')
+      expect(select.element.value).toBe('')
+
+      // Simulate user selection
+      await select.setValue('America/New_York')
+
+      // Should emit value for backend processing
+      expect(wrapper.emitted('update:modelValue')[0][0]).toBe('America/New_York')
+    })
+
+    it('handles read operation with timezone display', () => {
+      const phpFieldConfig = createMockField({
+        name: 'Timezone',
+        attribute: 'timezone',
+        component: 'TimezoneField',
+        options: {
+          'UTC': 'UTC',
+          'America/New_York': 'America/New_York',
+          'Europe/London': 'Europe/London'
+        }
+      })
+
+      wrapper = mount(TimezoneField, {
+        props: {
+          field: phpFieldConfig,
+          modelValue: 'America/New_York' // Existing record
+        }
+      })
+
+      // Should display existing value
+      const select = wrapper.find('select')
+      expect(select.element.value).toBe('America/New_York')
+    })
+
+    it('handles update operation with timezone change', async () => {
+      const phpFieldConfig = createMockField({
+        name: 'Timezone',
+        attribute: 'timezone',
+        component: 'TimezoneField',
+        options: {
+          'UTC': 'UTC',
+          'America/New_York': 'America/New_York',
+          'Europe/London': 'Europe/London'
+        }
+      })
+
+      wrapper = mount(TimezoneField, {
+        props: {
+          field: phpFieldConfig,
+          modelValue: 'America/New_York'
+        }
+      })
+
+      // Change timezone
+      const select = wrapper.find('select')
+      await select.setValue('Europe/London')
+
+      // Should emit new value for backend update
+      expect(wrapper.emitted('update:modelValue')[0][0]).toBe('Europe/London')
+    })
+  })
+
+  describe('Error Handling Integration', () => {
+    it('displays PHP validation errors correctly', () => {
+      const phpFieldConfig = createMockField({
+        name: 'Timezone',
+        attribute: 'timezone',
+        component: 'TimezoneField',
+        options: {
+          'UTC': 'UTC',
+          'America/New_York': 'America/New_York'
+        }
+      })
+
+      wrapper = mount(TimezoneField, {
+        props: {
+          field: phpFieldConfig,
+          modelValue: null,
+          errors: ['The timezone field is required.', 'Invalid timezone selected.']
+        }
+      })
+
+      // Should apply error styling
+      const select = wrapper.find('select')
+      expect(select.classes()).toContain('border-red-300')
+    })
+
+    it('handles disabled state from PHP', () => {
+      const phpFieldConfig = createMockField({
+        name: 'Timezone',
+        attribute: 'timezone',
+        component: 'TimezoneField',
+        options: {
+          'UTC': 'UTC',
+          'America/New_York': 'America/New_York'
+        }
+      })
+
+      wrapper = mount(TimezoneField, {
+        props: {
+          field: phpFieldConfig,
+          modelValue: 'America/New_York',
+          disabled: true
+        }
+      })
+
+      const select = wrapper.find('select')
+      expect(select.attributes('disabled')).toBeDefined()
+      expect(select.classes()).toContain('opacity-50')
+      expect(select.classes()).toContain('cursor-not-allowed')
+    })
+
+    it('handles readonly state from PHP', () => {
+      const phpFieldConfig = createMockField({
+        name: 'Timezone',
+        attribute: 'timezone',
+        component: 'TimezoneField',
+        options: {
+          'UTC': 'UTC',
+          'America/New_York': 'America/New_York'
+        }
+      })
+
+      wrapper = mount(TimezoneField, {
+        props: {
+          field: phpFieldConfig,
+          modelValue: 'America/New_York',
+          readonly: true
+        }
+      })
+
+      const select = wrapper.find('select')
+      expect(select.attributes('disabled')).toBeDefined()
+      expect(select.classes()).toContain('opacity-50')
+    })
+  })
+})

--- a/tests/Unit/Fields/TimezoneFieldTest.php
+++ b/tests/Unit/Fields/TimezoneFieldTest.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace JTD\AdminPanel\Tests\Unit\Fields;
 
+use DateTimeZone;
 use JTD\AdminPanel\Fields\Timezone;
 use JTD\AdminPanel\Tests\TestCase;
 
 /**
  * Timezone Field Unit Tests
  *
- * Tests for Timezone field class including validation, visibility,
- * and value handling.
+ * Tests for Timezone field class following Nova API compatibility.
+ * Tests basic field creation, timezone options, and meta data.
  *
  * @author Jeremy Fall <jerthedev@gmail.com>
  */
@@ -34,112 +35,75 @@ class TimezoneFieldTest extends TestCase
         $this->assertEquals('user_timezone', $field->attribute);
     }
 
-    public function test_timezone_field_default_properties(): void
+    public function test_timezone_field_meta_contains_options(): void
     {
         $field = Timezone::make('Timezone');
 
-        $this->assertTrue($field->searchable);
-        $this->assertFalse($field->groupByRegion);
-        $this->assertFalse($field->onlyCommon);
+        $meta = $field->meta();
+
+        $this->assertIsArray($meta);
+        $this->assertArrayHasKey('options', $meta);
+        $this->assertIsArray($meta['options']);
+        $this->assertNotEmpty($meta['options']);
     }
 
-    public function test_timezone_field_searchable_configuration(): void
-    {
-        $field = Timezone::make('Timezone')->searchable(false);
-
-        $this->assertFalse($field->searchable);
-    }
-
-    public function test_timezone_field_searchable_default(): void
+    public function test_timezone_field_options_include_all_php_timezones(): void
     {
         $field = Timezone::make('Timezone');
 
-        $this->assertTrue($field->searchable);
+        $meta = $field->meta();
+        $options = $meta['options'];
+        $phpTimezones = DateTimeZone::listIdentifiers();
+
+        // Should include all PHP timezones
+        foreach ($phpTimezones as $timezone) {
+            $this->assertArrayHasKey($timezone, $options);
+            $this->assertEquals($timezone, $options[$timezone]);
+        }
+
+        // Should have same count as PHP timezones
+        $this->assertCount(count($phpTimezones), $options);
     }
 
-    public function test_timezone_field_group_by_region_configuration(): void
-    {
-        $field = Timezone::make('Timezone')->groupByRegion();
-
-        $this->assertTrue($field->groupByRegion);
-    }
-
-    public function test_timezone_field_group_by_region_false(): void
-    {
-        $field = Timezone::make('Timezone')->groupByRegion(false);
-
-        $this->assertFalse($field->groupByRegion);
-    }
-
-    public function test_timezone_field_only_common_configuration(): void
-    {
-        $field = Timezone::make('Timezone')->onlyCommon();
-
-        $this->assertTrue($field->onlyCommon);
-    }
-
-    public function test_timezone_field_only_common_false(): void
-    {
-        $field = Timezone::make('Timezone')->onlyCommon(false);
-
-        $this->assertFalse($field->onlyCommon);
-    }
-
-    public function test_timezone_field_get_timezones_all(): void
+    public function test_timezone_field_options_are_sorted(): void
     {
         $field = Timezone::make('Timezone');
 
-        $timezones = $field->getTimezones();
+        $meta = $field->meta();
+        $options = $meta['options'];
 
-        $this->assertIsArray($timezones);
-        $this->assertNotEmpty($timezones);
-        $this->assertArrayHasKey('America/New_York', $timezones);
-        $this->assertArrayHasKey('Europe/London', $timezones);
-        $this->assertArrayHasKey('Asia/Tokyo', $timezones);
+        $sortedOptions = $options;
+        asort($sortedOptions);
+
+        $this->assertEquals($sortedOptions, $options);
     }
 
-    public function test_timezone_field_get_timezones_common_only(): void
+    public function test_timezone_field_options_contain_common_timezones(): void
     {
-        $field = Timezone::make('Timezone')->onlyCommon();
+        $field = Timezone::make('Timezone');
 
-        $timezones = $field->getTimezones();
-
-        $this->assertIsArray($timezones);
-        $this->assertNotEmpty($timezones);
+        $meta = $field->meta();
+        $options = $meta['options'];
 
         // Should contain common timezones
-        $this->assertArrayHasKey('America/New_York', $timezones);
-        $this->assertArrayHasKey('Europe/London', $timezones);
-        $this->assertArrayHasKey('Asia/Tokyo', $timezones);
-
-        // Should be smaller than full list
-        $allTimezones = Timezone::make('Timezone')->getTimezones();
-        $this->assertLessThan(count($allTimezones), count($timezones));
+        $this->assertArrayHasKey('America/New_York', $options);
+        $this->assertArrayHasKey('Europe/London', $options);
+        $this->assertArrayHasKey('Asia/Tokyo', $options);
+        $this->assertArrayHasKey('UTC', $options);
+        $this->assertArrayHasKey('Australia/Sydney', $options);
     }
 
-    public function test_timezone_field_get_timezones_excludes_deprecated(): void
+    public function test_timezone_field_options_values_equal_keys(): void
     {
         $field = Timezone::make('Timezone');
 
-        $timezones = $field->getTimezones();
+        $meta = $field->meta();
+        $options = $meta['options'];
 
-        // Should not contain deprecated timezones (those without '/')
-        foreach (array_keys($timezones) as $identifier) {
-            $this->assertStringContainsString('/', $identifier, "Timezone {$identifier} should contain '/'");
+        // In Nova's simple API, timezone values should equal their keys
+        foreach ($options as $key => $value) {
+            $this->assertEquals($key, $value);
         }
-    }
-
-    public function test_timezone_field_get_timezones_formats_names(): void
-    {
-        $field = Timezone::make('Timezone');
-
-        $timezones = $field->getTimezones();
-
-        // Test specific formatting examples
-        $this->assertStringContainsString('New York', $timezones['America/New_York']);
-        $this->assertStringContainsString('America', $timezones['America/New_York']);
-        $this->assertStringContainsString('London', $timezones['Europe/London']);
-        $this->assertStringContainsString('Europe', $timezones['Europe/London']);
     }
 
     public function test_timezone_field_fill_validates_timezone(): void
@@ -177,61 +141,6 @@ class TimezoneFieldTest extends TestCase
         $this->assertEquals('UTC', $model->timezone);
     }
 
-    public function test_timezone_field_meta_includes_all_properties(): void
-    {
-        $field = Timezone::make('Timezone')
-            ->searchable(false)
-            ->groupByRegion()
-            ->onlyCommon();
-
-        $meta = $field->meta();
-
-        $this->assertArrayHasKey('searchable', $meta);
-        $this->assertArrayHasKey('groupByRegion', $meta);
-        $this->assertArrayHasKey('onlyCommon', $meta);
-        $this->assertArrayHasKey('timezones', $meta);
-        $this->assertFalse($meta['searchable']);
-        $this->assertTrue($meta['groupByRegion']);
-        $this->assertTrue($meta['onlyCommon']);
-        $this->assertIsArray($meta['timezones']);
-    }
-
-    public function test_timezone_field_json_serialization(): void
-    {
-        $field = Timezone::make('User Timezone')
-            ->searchable()
-            ->groupByRegion()
-            ->onlyCommon()
-            ->required()
-            ->help('Select your timezone');
-
-        $json = $field->jsonSerialize();
-
-        $this->assertEquals('User Timezone', $json['name']);
-        $this->assertEquals('user_timezone', $json['attribute']);
-        $this->assertEquals('TimezoneField', $json['component']);
-        $this->assertTrue($json['searchable']);
-        $this->assertTrue($json['groupByRegion']);
-        $this->assertTrue($json['onlyCommon']);
-        $this->assertIsArray($json['timezones']);
-        $this->assertContains('required', $json['rules']);
-        $this->assertEquals('Select your timezone', $json['helpText']);
-    }
-
-    public function test_timezone_field_common_timezones_functionality(): void
-    {
-        $field = Timezone::make('Timezone')->onlyCommon();
-
-        $commonTimezones = $field->getTimezones();
-
-        // Test that common timezones are returned when onlyCommon is true
-        $this->assertIsArray($commonTimezones);
-        $this->assertArrayHasKey('UTC', $commonTimezones);
-        $this->assertArrayHasKey('America/New_York', $commonTimezones);
-        $this->assertArrayHasKey('Europe/London', $commonTimezones);
-        $this->assertArrayHasKey('Asia/Tokyo', $commonTimezones);
-    }
-
     public function test_timezone_field_inheritance_from_field(): void
     {
         $field = Timezone::make('Timezone');
@@ -242,6 +151,23 @@ class TimezoneFieldTest extends TestCase
         $this->assertTrue(method_exists($field, 'readonly'));
         $this->assertTrue(method_exists($field, 'help'));
         $this->assertTrue(method_exists($field, 'placeholder'));
+    }
+
+    public function test_timezone_field_json_serialization(): void
+    {
+        $field = Timezone::make('User Timezone')
+            ->required()
+            ->help('Select your timezone');
+
+        $json = $field->jsonSerialize();
+
+        $this->assertEquals('User Timezone', $json['name']);
+        $this->assertEquals('user_timezone', $json['attribute']);
+        $this->assertEquals('TimezoneField', $json['component']);
+        $this->assertArrayHasKey('options', $json);
+        $this->assertIsArray($json['options']);
+        $this->assertContains('required', $json['rules']);
+        $this->assertEquals('Select your timezone', $json['helpText']);
     }
 
     public function test_timezone_field_with_validation_rules(): void
@@ -262,104 +188,25 @@ class TimezoneFieldTest extends TestCase
         $this->assertEquals('America/Los_Angeles', $field->value);
     }
 
-    public function test_timezone_field_get_timezones_grouped(): void
+    public function test_timezone_field_comprehensive_coverage(): void
     {
         $field = Timezone::make('Timezone');
 
-        $groupedTimezones = $field->getTimezonesGrouped();
-
-        $this->assertIsArray($groupedTimezones);
-        $this->assertNotEmpty($groupedTimezones);
-
-        // Should have regional groups
-        $this->assertArrayHasKey('America', $groupedTimezones);
-        $this->assertArrayHasKey('Europe', $groupedTimezones);
-        $this->assertArrayHasKey('Asia', $groupedTimezones);
-
-        // Each region should contain timezones
-        $this->assertIsArray($groupedTimezones['America']);
-        $this->assertArrayHasKey('America/New_York', $groupedTimezones['America']);
-        $this->assertArrayHasKey('America/Los_Angeles', $groupedTimezones['America']);
-
-        $this->assertIsArray($groupedTimezones['Europe']);
-        $this->assertArrayHasKey('Europe/London', $groupedTimezones['Europe']);
-        $this->assertArrayHasKey('Europe/Paris', $groupedTimezones['Europe']);
-
-        // Test that regions are sorted
-        $regions = array_keys($groupedTimezones);
-        $sortedRegions = $regions;
-        sort($sortedRegions);
-        $this->assertEquals($sortedRegions, $regions);
-    }
-
-    public function test_timezone_field_get_timezones_grouped_with_common_only(): void
-    {
-        $field = Timezone::make('Timezone')->onlyCommon();
-
-        $groupedTimezones = $field->getTimezonesGrouped();
-
-        $this->assertIsArray($groupedTimezones);
-        $this->assertNotEmpty($groupedTimezones);
-
-        // Should contain common timezone regions
-        $this->assertArrayHasKey('America', $groupedTimezones);
-        $this->assertArrayHasKey('Europe', $groupedTimezones);
-        $this->assertArrayHasKey('Asia', $groupedTimezones);
-
-        // Should be smaller than full grouped list
-        $allGroupedTimezones = Timezone::make('Timezone')->getTimezonesGrouped();
-        $this->assertLessThanOrEqual(count($allGroupedTimezones), count($groupedTimezones));
-    }
-
-    public function test_timezone_field_meta_uses_grouped_when_enabled(): void
-    {
-        $field = Timezone::make('Timezone')->groupByRegion();
-
-        $meta = $field->meta();
-
-        $this->assertArrayHasKey('timezones', $meta);
-        $this->assertIsArray($meta['timezones']);
-        $this->assertTrue($meta['groupByRegion']);
-
-        // When groupByRegion is true, timezones should be grouped
-        $this->assertArrayHasKey('America', $meta['timezones']);
-        $this->assertArrayHasKey('Europe', $meta['timezones']);
-    }
-
-    public function test_timezone_field_comprehensive_method_coverage(): void
-    {
-        $field = Timezone::make('Timezone');
-
-        // Test all public methods to ensure complete coverage
-        $this->assertTrue(method_exists($field, 'searchable'));
-        $this->assertTrue(method_exists($field, 'groupByRegion'));
-        $this->assertTrue(method_exists($field, 'onlyCommon'));
-        $this->assertTrue(method_exists($field, 'getTimezones'));
-        $this->assertTrue(method_exists($field, 'getTimezonesGrouped'));
+        // Test all public methods exist and work
         $this->assertTrue(method_exists($field, 'meta'));
-
-        // Call all methods to ensure they're covered
-        $field->searchable();
-        $field->groupByRegion();
-        $field->onlyCommon();
-
-        $timezones = $field->getTimezones();
-        $this->assertIsArray($timezones);
-
-        $groupedTimezones = $field->getTimezonesGrouped();
-        $this->assertIsArray($groupedTimezones);
 
         $meta = $field->meta();
         $this->assertIsArray($meta);
+        $this->assertArrayHasKey('options', $meta);
 
-        // Test method chaining
+        // Test method chaining with base Field methods
         $chainedField = Timezone::make('Timezone')
-            ->searchable()
-            ->groupByRegion()
-            ->onlyCommon();
+            ->required()
+            ->help('Select timezone')
+            ->placeholder('Choose timezone...');
 
-        $this->assertTrue($chainedField->searchable);
-        $this->assertTrue($chainedField->groupByRegion);
-        $this->assertTrue($chainedField->onlyCommon);
+        $this->assertContains('required', $chainedField->rules);
+        $this->assertEquals('Select timezone', $chainedField->helpText);
+        $this->assertEquals('Choose timezone...', $chainedField->placeholder);
     }
 }

--- a/tests/e2e/fields/TimezoneFieldE2ETest.php
+++ b/tests/e2e/fields/TimezoneFieldE2ETest.php
@@ -1,0 +1,381 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\E2E\Fields;
+
+use DateTimeZone;
+use Illuminate\Http\Request;
+use JTD\AdminPanel\Fields\Timezone;
+use JTD\AdminPanel\Tests\TestCase;
+
+/**
+ * End-to-end tests for Timezone field covering the complete flow:
+ * PHP Field -> JSON Serialization -> Client Processing -> Form Submission -> PHP Fill
+ *
+ * Tests real-world usage scenarios with Nova API compatibility.
+ *
+ * @author Jeremy Fall <jerthedev@gmail.com>
+ */
+class TimezoneFieldE2ETest extends TestCase
+{
+    /** @test */
+    public function it_handles_complete_timezone_field_flow_basic(): void
+    {
+        // 1. Create Timezone field (PHP)
+        $field = Timezone::make('User Timezone')
+            ->required()
+            ->help('Select your timezone');
+
+        // 2. Serialize for frontend (simulates API response)
+        $serialized = $field->jsonSerialize();
+
+        // 3. Verify frontend receives correct structure
+        $this->assertEquals('TimezoneField', $serialized['component']);
+        $this->assertEquals('User Timezone', $serialized['name']);
+        $this->assertEquals('user_timezone', $serialized['attribute']);
+        $this->assertArrayHasKey('options', $serialized);
+        $this->assertIsArray($serialized['options']);
+        $this->assertNotEmpty($serialized['options']);
+        $this->assertContains('required', $serialized['rules']);
+
+        // 4. Simulate form submission (client -> server)
+        $newField = Timezone::make('User Timezone');
+        $model = new \stdClass();
+        $request = new Request(['user_timezone' => 'America/New_York']);
+        $newField->fill($request, $model);
+
+        // 5. Verify final storage
+        $this->assertEquals('America/New_York', $model->user_timezone);
+    }
+
+    /** @test */
+    public function it_handles_complete_timezone_field_flow_with_validation(): void
+    {
+        // 1. Create Timezone field with validation
+        $field = Timezone::make('Timezone')
+            ->rules('required', 'timezone')
+            ->nullable(false);
+
+        // 2. Serialize for frontend
+        $serialized = $field->jsonSerialize();
+
+        // 3. Verify validation rules are included
+        $this->assertContains('required', $serialized['rules']);
+        $this->assertContains('timezone', $serialized['rules']);
+        $this->assertFalse($serialized['nullable']);
+
+        // 4. Test valid timezone submission
+        $newField = Timezone::make('Timezone')->rules('required', 'timezone');
+        $model = new \stdClass();
+        $request = new Request(['timezone' => 'Europe/London']);
+        $newField->fill($request, $model);
+
+        $this->assertEquals('Europe/London', $model->timezone);
+
+        // 5. Test empty submission (should be handled by validation)
+        $emptyModel = new \stdClass();
+        $emptyRequest = new Request(['timezone' => '']);
+        $newField->fill($emptyRequest, $emptyModel);
+
+        $this->assertEquals('', $emptyModel->timezone);
+    }
+
+    /** @test */
+    public function it_handles_complete_timezone_field_flow_nullable(): void
+    {
+        // 1. Create nullable Timezone field
+        $field = Timezone::make('Optional Timezone')
+            ->nullable()
+            ->placeholder('Choose timezone (optional)');
+
+        // 2. Serialize for frontend
+        $serialized = $field->jsonSerialize();
+
+        // 3. Verify nullable configuration
+        $this->assertTrue($serialized['nullable']);
+        $this->assertEquals('Choose timezone (optional)', $serialized['placeholder']);
+
+        // 4. Test null submission
+        $newField = Timezone::make('Optional Timezone')->nullable();
+        $model = new \stdClass();
+        $request = new Request(['optional_timezone' => null]);
+        $newField->fill($request, $model);
+
+        $this->assertNull($model->optional_timezone);
+
+        // 5. Test empty string submission
+        $emptyModel = new \stdClass();
+        $emptyRequest = new Request(['optional_timezone' => '']);
+        $newField->fill($emptyRequest, $emptyModel);
+
+        $this->assertEquals('', $emptyModel->optional_timezone);
+    }
+
+    /** @test */
+    public function it_handles_all_php_timezones_end_to_end(): void
+    {
+        // 1. Create Timezone field
+        $field = Timezone::make('Timezone');
+
+        // 2. Get serialized options
+        $serialized = $field->jsonSerialize();
+        $options = $serialized['options'];
+
+        // 3. Verify all PHP timezones are available
+        $phpTimezones = DateTimeZone::listIdentifiers();
+        foreach ($phpTimezones as $timezone) {
+            $this->assertArrayHasKey($timezone, $options);
+            $this->assertEquals($timezone, $options[$timezone]);
+        }
+
+        // 4. Test submission with various timezone types
+        $testTimezones = [
+            'UTC',
+            'America/New_York',
+            'Europe/London',
+            'Asia/Tokyo',
+            'Australia/Sydney',
+            'Pacific/Honolulu',
+            'Antarctica/McMurdo',
+            'America/Argentina/Buenos_Aires',
+        ];
+
+        foreach ($testTimezones as $timezone) {
+            if (in_array($timezone, $phpTimezones)) {
+                $newField = Timezone::make('Timezone');
+                $model = new \stdClass();
+                $request = new Request(['timezone' => $timezone]);
+                $newField->fill($request, $model);
+
+                $this->assertEquals($timezone, $model->timezone);
+            }
+        }
+    }
+
+    /** @test */
+    public function it_handles_timezone_field_with_default_values(): void
+    {
+        // 1. Create field with default value
+        $field = Timezone::make('Timezone')->default('UTC');
+
+        // 2. Serialize for frontend
+        $serialized = $field->jsonSerialize();
+
+        // 3. Verify default is included
+        $this->assertEquals('UTC', $serialized['default']);
+
+        // 4. Test with callable default
+        $callableField = Timezone::make('Timezone')->default(function () {
+            return 'America/New_York';
+        });
+
+        $callableSerialized = $callableField->jsonSerialize();
+        $this->assertIsCallable($callableSerialized['default']);
+
+        // 5. Test form submission overrides default
+        $newField = Timezone::make('Timezone')->default('UTC');
+        $model = new \stdClass();
+        $request = new Request(['timezone' => 'Europe/London']);
+        $newField->fill($request, $model);
+
+        $this->assertEquals('Europe/London', $model->timezone);
+    }
+
+    /** @test */
+    public function it_handles_timezone_field_with_custom_callback(): void
+    {
+        // 1. Create field with custom fill callback
+        $field = Timezone::make('Timezone')->fillUsing(function ($request, $model, $attribute) {
+            // Custom logic: always set to UTC regardless of input
+            $model->{$attribute} = 'UTC';
+        });
+
+        // 2. Test custom callback behavior
+        $model = new \stdClass();
+        $request = new Request(['timezone' => 'America/New_York']);
+        $field->fill($request, $model);
+
+        // Should use custom callback, not the submitted value
+        $this->assertEquals('UTC', $model->timezone);
+    }
+
+    /** @test */
+    public function it_handles_timezone_field_resolution_flow(): void
+    {
+        // 1. Create field for resolution
+        $field = Timezone::make('User Timezone');
+
+        // 2. Test resolving from model
+        $resource = (object) ['user_timezone' => 'America/New_York'];
+        $field->resolve($resource);
+
+        $this->assertEquals('America/New_York', $field->value);
+
+        // 3. Test resolving null value
+        $nullResource = (object) ['user_timezone' => null];
+        $field->resolve($nullResource);
+
+        $this->assertNull($field->value);
+
+        // 4. Test with custom resolve callback
+        $customField = Timezone::make('Timezone')->resolveUsing(function ($resource, $attribute) {
+            return 'UTC'; // Always return UTC
+        });
+
+        $customField->resolve($resource);
+        $this->assertEquals('UTC', $customField->value);
+    }
+
+    /** @test */
+    public function it_handles_timezone_field_edge_cases(): void
+    {
+        // 1. Test with edge case timezones
+        $field = Timezone::make('Timezone');
+        $serialized = $field->jsonSerialize();
+
+        $edgeCases = [
+            'GMT',
+            'UTC',
+            'Pacific/Kiritimati', // UTC+14
+            'Pacific/Niue', // UTC-11
+            'America/Argentina/Buenos_Aires', // Long name
+            'Antarctica/McMurdo', // Antarctica
+        ];
+
+        foreach ($edgeCases as $timezone) {
+            if (in_array($timezone, DateTimeZone::listIdentifiers())) {
+                $this->assertArrayHasKey($timezone, $serialized['options']);
+
+                // Test submission
+                $newField = Timezone::make('Timezone');
+                $model = new \stdClass();
+                $request = new Request(['timezone' => $timezone]);
+                $newField->fill($request, $model);
+
+                $this->assertEquals($timezone, $model->timezone);
+            }
+        }
+    }
+
+    /** @test */
+    public function it_handles_timezone_field_nova_api_compatibility_flow(): void
+    {
+        // 1. Create field using Nova API methods
+        $field = Timezone::make('User Timezone')
+            ->required()
+            ->nullable()
+            ->help('Select your timezone')
+            ->placeholder('Choose timezone...')
+            ->sortable()
+            ->hideFromIndex()
+            ->showOnDetail();
+
+        // 2. Serialize for frontend
+        $serialized = $field->jsonSerialize();
+
+        // 3. Verify Nova API properties are preserved
+        $this->assertEquals('User Timezone', $serialized['name']);
+        $this->assertEquals('user_timezone', $serialized['attribute']);
+        $this->assertEquals('TimezoneField', $serialized['component']);
+        $this->assertContains('required', $serialized['rules']);
+        $this->assertTrue($serialized['nullable']);
+        $this->assertEquals('Select your timezone', $serialized['helpText']);
+        $this->assertEquals('Choose timezone...', $serialized['placeholder']);
+        $this->assertTrue($serialized['sortable']);
+        $this->assertFalse($serialized['showOnIndex']);
+        $this->assertTrue($serialized['showOnDetail']);
+
+        // 4. Test complete CRUD flow
+        $newField = Timezone::make('User Timezone');
+
+        // Create
+        $createModel = new \stdClass();
+        $createRequest = new Request(['user_timezone' => 'America/New_York']);
+        $newField->fill($createRequest, $createModel);
+        $this->assertEquals('America/New_York', $createModel->user_timezone);
+
+        // Read
+        $readField = Timezone::make('User Timezone');
+        $readField->resolve($createModel);
+        $this->assertEquals('America/New_York', $readField->value);
+
+        // Update
+        $updateModel = $createModel;
+        $updateRequest = new Request(['user_timezone' => 'Europe/London']);
+        $newField->fill($updateRequest, $updateModel);
+        $this->assertEquals('Europe/London', $updateModel->user_timezone);
+    }
+
+    /** @test */
+    public function it_handles_timezone_field_sorting_and_options(): void
+    {
+        // 1. Create field
+        $field = Timezone::make('Timezone');
+
+        // 2. Get options
+        $serialized = $field->jsonSerialize();
+        $options = $serialized['options'];
+
+        // 3. Verify options are sorted
+        $sortedOptions = $options;
+        asort($sortedOptions);
+        $this->assertEquals($sortedOptions, $options);
+
+        // 4. Verify all options are valid timezone identifiers
+        foreach (array_keys($options) as $timezone) {
+            $this->assertContains($timezone, DateTimeZone::listIdentifiers());
+        }
+
+        // 5. Verify options format (key equals value)
+        foreach ($options as $key => $value) {
+            $this->assertEquals($key, $value);
+            $this->assertIsString($key);
+            $this->assertIsString($value);
+        }
+    }
+
+    /** @test */
+    public function it_handles_timezone_field_real_world_scenarios(): void
+    {
+        // Scenario 1: User registration with timezone
+        $registrationField = Timezone::make('Timezone')
+            ->required()
+            ->help('This helps us show you times in your local timezone');
+
+        $user = new \stdClass();
+        $registrationRequest = new Request(['timezone' => 'America/Los_Angeles']);
+        $registrationField->fill($registrationRequest, $user);
+        $this->assertEquals('America/Los_Angeles', $user->timezone);
+
+        // Scenario 2: Event scheduling with timezone
+        $eventField = Timezone::make('Event Timezone')
+            ->default('UTC')
+            ->help('Timezone for this event');
+
+        $event = new \stdClass();
+        $eventRequest = new Request(['event_timezone' => 'Europe/Paris']);
+        $eventField->fill($eventRequest, $event);
+        $this->assertEquals('Europe/Paris', $event->event_timezone);
+
+        // Scenario 3: Optional timezone in profile
+        $profileField = Timezone::make('Preferred Timezone')
+            ->nullable()
+            ->placeholder('Leave empty to use system default');
+
+        $profile = new \stdClass();
+        $profileRequest = new Request(['preferred_timezone' => '']);
+        $profileField->fill($profileRequest, $profile);
+        $this->assertEquals('', $profile->preferred_timezone);
+
+        // Scenario 4: Admin setting global timezone
+        $adminField = Timezone::make('System Timezone')
+            ->default('UTC')
+            ->help('Default timezone for the application');
+
+        $settings = new \stdClass();
+        $adminRequest = new Request(['system_timezone' => 'America/New_York']);
+        $adminField->fill($adminRequest, $settings);
+        $this->assertEquals('America/New_York', $settings->system_timezone);
+    }
+}

--- a/tests/e2e/fields/components/timezone-field.spec.js
+++ b/tests/e2e/fields/components/timezone-field.spec.js
@@ -1,0 +1,320 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * End-to-End tests for Timezone field using Playwright
+ * 
+ * Tests real-world user interactions and complete workflows
+ * with the Timezone field in the admin panel.
+ */
+
+test.describe('Timezone Field E2E', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to a form with timezone field
+    await page.goto('/admin/test-form-with-timezone')
+  })
+
+  test('should display timezone field with proper attributes', async ({ page }) => {
+    // Locate the timezone field
+    const timezoneField = page.locator('[data-testid="timezone-field-user-timezone"]')
+    await expect(timezoneField).toBeVisible()
+
+    // Check select element and attributes
+    const select = timezoneField.locator('select')
+    await expect(select).toBeVisible()
+    await expect(select).toHaveAttribute('name', 'user_timezone')
+
+    // Check placeholder option
+    const placeholder = select.locator('option[value=""]')
+    await expect(placeholder).toBeVisible()
+    await expect(placeholder).toHaveText('Select timezone...')
+
+    // Check that timezone options are present
+    const options = select.locator('option:not([value=""])')
+    const optionCount = await options.count()
+    expect(optionCount).toBeGreaterThan(400) // Should have many timezone options
+  })
+
+  test('should allow timezone selection', async ({ page }) => {
+    const select = page.locator('[data-testid="timezone-field-user-timezone"] select')
+    
+    // Select a timezone
+    await select.selectOption('America/New_York')
+    
+    // Verify selection
+    await expect(select).toHaveValue('America/New_York')
+    
+    // Change to different timezone
+    await select.selectOption('Europe/London')
+    await expect(select).toHaveValue('Europe/London')
+    
+    // Change to UTC
+    await select.selectOption('UTC')
+    await expect(select).toHaveValue('UTC')
+  })
+
+  test('should handle form submission with timezone', async ({ page }) => {
+    const select = page.locator('[data-testid="timezone-field-user-timezone"] select')
+    
+    // Fill form with timezone
+    await select.selectOption('America/Los_Angeles')
+    await page.fill('[data-testid="text-field-name"] input', 'Test User')
+    
+    // Submit form
+    await page.click('[data-testid="submit-button"]')
+    
+    // Should redirect to success page or show success message
+    await expect(page).toHaveURL(/\/admin\/.*\/\d+/)
+    
+    // Verify timezone was saved
+    const timezoneDisplay = page.locator('[data-testid="timezone-display-user-timezone"]')
+    await expect(timezoneDisplay).toContainText('America/Los_Angeles')
+  })
+
+  test('should display validation errors', async ({ page }) => {
+    // Try to submit form without selecting required timezone
+    await page.click('[data-testid="submit-button"]')
+    
+    // Should show validation error
+    const errorMessage = page.locator('[data-testid="field-error-user-timezone"]')
+    await expect(errorMessage).toBeVisible()
+    await expect(errorMessage).toContainText('required')
+  })
+
+  test('should handle nullable timezone field', async ({ page }) => {
+    // Navigate to form with nullable timezone
+    await page.goto('/admin/test-form-with-nullable-timezone')
+    
+    const select = page.locator('[data-testid="timezone-field-optional-timezone"] select')
+    
+    // Should start with no selection
+    await expect(select).toHaveValue('')
+    
+    // Should allow submission without selection
+    await page.fill('[data-testid="text-field-name"] input', 'Test User')
+    await page.click('[data-testid="submit-button"]')
+    
+    // Should succeed
+    await expect(page).toHaveURL(/\/admin\/.*\/\d+/)
+  })
+
+  test('should display timezone options in correct format', async ({ page }) => {
+    const select = page.locator('[data-testid="timezone-field-user-timezone"] select')
+    
+    // Check specific timezone options format
+    const utcOption = select.locator('option[value="UTC"]')
+    await expect(utcOption).toHaveText('UTC')
+    
+    const nyOption = select.locator('option[value="America/New_York"]')
+    await expect(nyOption).toHaveText('America/New_York')
+    
+    const londonOption = select.locator('option[value="Europe/London"]')
+    await expect(londonOption).toHaveText('Europe/London')
+    
+    const tokyoOption = select.locator('option[value="Asia/Tokyo"]')
+    await expect(tokyoOption).toHaveText('Asia/Tokyo')
+  })
+
+  test('should handle disabled state', async ({ page }) => {
+    // Navigate to form with disabled timezone field
+    await page.goto('/admin/test-form-with-disabled-timezone')
+    
+    const select = page.locator('[data-testid="timezone-field-disabled-timezone"] select')
+    
+    // Should be disabled
+    await expect(select).toBeDisabled()
+    
+    // Should have disabled styling
+    await expect(select).toHaveClass(/opacity-50/)
+    await expect(select).toHaveClass(/cursor-not-allowed/)
+  })
+
+  test('should handle readonly state', async ({ page }) => {
+    // Navigate to form with readonly timezone field
+    await page.goto('/admin/test-form-with-readonly-timezone')
+    
+    const select = page.locator('[data-testid="timezone-field-readonly-timezone"] select')
+    
+    // Should be disabled (readonly is implemented as disabled for selects)
+    await expect(select).toBeDisabled()
+    
+    // Should show existing value
+    await expect(select).toHaveValue('America/New_York')
+  })
+
+  test('should work in dark theme', async ({ page }) => {
+    // Enable dark theme
+    await page.goto('/admin/settings/appearance')
+    await page.click('[data-testid="dark-theme-toggle"]')
+    
+    // Navigate to timezone form
+    await page.goto('/admin/test-form-with-timezone')
+    
+    const select = page.locator('[data-testid="timezone-field-user-timezone"] select')
+    
+    // Should have dark theme classes
+    await expect(select).toHaveClass(/admin-input-dark/)
+    
+    // Should still be functional
+    await select.selectOption('Europe/Paris')
+    await expect(select).toHaveValue('Europe/Paris')
+  })
+
+  test('should handle error states', async ({ page }) => {
+    const select = page.locator('[data-testid="timezone-field-user-timezone"] select')
+    
+    // Submit form to trigger validation error
+    await page.click('[data-testid="submit-button"]')
+    
+    // Field should have error styling
+    await expect(select).toHaveClass(/border-red-300/)
+    
+    // Fix the error
+    await select.selectOption('UTC')
+    
+    // Error styling should be removed after fixing
+    await expect(select).not.toHaveClass(/border-red-300/)
+  })
+
+  test('should handle all common timezones', async ({ page }) => {
+    const select = page.locator('[data-testid="timezone-field-user-timezone"] select')
+    
+    // Test common timezones
+    const commonTimezones = [
+      'UTC',
+      'America/New_York',
+      'America/Chicago', 
+      'America/Denver',
+      'America/Los_Angeles',
+      'Europe/London',
+      'Europe/Paris',
+      'Asia/Tokyo',
+      'Australia/Sydney'
+    ]
+    
+    for (const timezone of commonTimezones) {
+      await select.selectOption(timezone)
+      await expect(select).toHaveValue(timezone)
+    }
+  })
+
+  test('should handle edge case timezones', async ({ page }) => {
+    const select = page.locator('[data-testid="timezone-field-user-timezone"] select')
+    
+    // Test edge case timezones
+    const edgeTimezones = [
+      'Pacific/Kiritimati', // UTC+14
+      'Pacific/Niue', // UTC-11
+      'America/Argentina/Buenos_Aires', // Long name
+      'Antarctica/McMurdo' // Antarctica
+    ]
+    
+    for (const timezone of edgeTimezones) {
+      // Check if option exists (some might not be available)
+      const option = select.locator(`option[value="${timezone}"]`)
+      const exists = await option.count() > 0
+      
+      if (exists) {
+        await select.selectOption(timezone)
+        await expect(select).toHaveValue(timezone)
+      }
+    }
+  })
+
+  test('should maintain selection during form interactions', async ({ page }) => {
+    const select = page.locator('[data-testid="timezone-field-user-timezone"] select')
+    
+    // Select timezone
+    await select.selectOption('Asia/Tokyo')
+    await expect(select).toHaveValue('Asia/Tokyo')
+    
+    // Interact with other form fields
+    await page.fill('[data-testid="text-field-name"] input', 'Test User')
+    await page.fill('[data-testid="email-field-email"] input', 'test@example.com')
+    
+    // Timezone selection should be maintained
+    await expect(select).toHaveValue('Asia/Tokyo')
+    
+    // Focus and blur the timezone field
+    await select.focus()
+    await select.blur()
+    
+    // Selection should still be maintained
+    await expect(select).toHaveValue('Asia/Tokyo')
+  })
+
+  test('should work with form reset', async ({ page }) => {
+    const select = page.locator('[data-testid="timezone-field-user-timezone"] select')
+    
+    // Select timezone
+    await select.selectOption('Europe/Berlin')
+    await expect(select).toHaveValue('Europe/Berlin')
+    
+    // Reset form
+    await page.click('[data-testid="reset-button"]')
+    
+    // Should return to default/empty state
+    await expect(select).toHaveValue('')
+  })
+
+  test('should handle keyboard navigation', async ({ page }) => {
+    const select = page.locator('[data-testid="timezone-field-user-timezone"] select')
+    
+    // Focus the select
+    await select.focus()
+    
+    // Use keyboard to navigate
+    await page.keyboard.press('ArrowDown') // Open dropdown
+    await page.keyboard.press('ArrowDown') // Move to first option
+    await page.keyboard.press('Enter') // Select option
+    
+    // Should have selected a timezone
+    const value = await select.inputValue()
+    expect(value).not.toBe('')
+  })
+
+  test('should display help text', async ({ page }) => {
+    // Navigate to form with help text
+    await page.goto('/admin/test-form-with-timezone-help')
+    
+    const helpText = page.locator('[data-testid="field-help-user-timezone"]')
+    await expect(helpText).toBeVisible()
+    await expect(helpText).toContainText('Select your timezone')
+  })
+
+  test('should handle real-world user scenarios', async ({ page }) => {
+    // Scenario 1: User registration
+    await page.goto('/admin/users/create')
+    
+    await page.fill('[data-testid="text-field-name"] input', 'John Doe')
+    await page.fill('[data-testid="email-field-email"] input', 'john@example.com')
+    
+    const timezoneSelect = page.locator('[data-testid="timezone-field-timezone"] select')
+    await timezoneSelect.selectOption('America/New_York')
+    
+    await page.click('[data-testid="create-button"]')
+    await expect(page).toHaveURL(/\/admin\/users\/\d+/)
+    
+    // Verify timezone is displayed
+    const timezoneDisplay = page.locator('[data-testid="timezone-display-timezone"]')
+    await expect(timezoneDisplay).toContainText('America/New_York')
+  })
+
+  test('should handle form validation with other fields', async ({ page }) => {
+    const select = page.locator('[data-testid="timezone-field-user-timezone"] select')
+    
+    // Select timezone but leave other required fields empty
+    await select.selectOption('UTC')
+    await page.click('[data-testid="submit-button"]')
+    
+    // Should show validation errors for other fields
+    const nameError = page.locator('[data-testid="field-error-name"]')
+    await expect(nameError).toBeVisible()
+    
+    // Timezone field should not have error
+    const timezoneError = page.locator('[data-testid="field-error-user-timezone"]')
+    await expect(timezoneError).not.toBeVisible()
+    
+    // Timezone selection should be maintained
+    await expect(select).toHaveValue('UTC')
+  })
+})


### PR DESCRIPTION
## 🎯 Overview

Completes JTDAP-200 by implementing full Nova API compatibility for the Timezone field. This PR removes all non-Nova features and ensures the field matches Nova's simple Timezone field API exactly.

## ✅ Changes Made

### 1. Nova API Compatibility
- ✅ Removed non-Nova features: `searchable()`, `groupByRegion()`, `onlyCommon()`
- ✅ Simplified PHP field to use all PECL timezones as options
- ✅ Ensured ALL timezones from PECL database are included (400+ timezones)
- ✅ Field now uses simple `options` array with timezone identifiers

### 2. Vue Component Simplification
- ✅ Changed from complex dropdown to basic HTML select element
- ✅ Removed search input, region grouping, current time display
- ✅ Now matches Nova docs: "generates a Select field containing a list of the world's timezones"

### 3. Comprehensive Test Coverage
- ✅ **PHP Unit Tests**: 20 tests, 2,584 assertions
- ✅ **Vue Component Tests**: 19 tests
- ✅ **Integration Tests**: 36 tests (20 PHP + 16 JS)
- ✅ **E2E Tests**: 11 PHP tests + Playwright scenarios

## 🧪 Test Results

All tests passing:
- ✅ PHP Unit Tests: 20/20 tests, 2,584 assertions
- ✅ Vue Component Tests: 19/19 tests
- ✅ PHP Integration Tests: 20/20 tests
- ✅ JS Integration Tests: 16/16 tests
- ✅ PHP E2E Tests: 11/11 tests, 2,574 assertions
- ✅ Playwright E2E Tests: Written and ready

## 📋 Files Changed

### Core Implementation
- `src/Fields/Timezone.php` - Simplified to match Nova API
- `resources/js/components/Fields/TimezoneField.vue` - Basic select field

### Tests
- `tests/Unit/Fields/TimezoneFieldTest.php` - Updated unit tests
- `tests/components/Fields/TimezoneField.test.js` - Updated component tests
- `tests/Integration/Fields/TimezoneFieldIntegrationTest.php` - New integration tests
- `tests/Integration/Fields/components/TimezoneFieldIntegration.test.js` - New JS integration tests
- `tests/e2e/fields/TimezoneFieldE2ETest.php` - New E2E tests
- `tests/e2e/fields/components/timezone-field.spec.js` - New Playwright tests

## 🔍 Key Technical Details

### Before (Non-Nova Features)
```php
// Old implementation had extra features
$field = Timezone::make('Timezone')
    ->searchable()
    ->groupByRegion()
    ->onlyCommon();
```

### After (Nova Compatible)
```php
// Now matches Nova exactly
$field = Timezone::make('Timezone'); // Simple select with all timezones
```

### Timezone Coverage
- ✅ All PECL timezone identifiers included
- ✅ Properly sorted alphabetically
- ✅ Edge cases handled (UTC, GMT, long names, etc.)
- ✅ No deprecated timezones excluded

## 🎉 Result

The Timezone field is now **production-ready** with:
- ✅ 100% Nova API compatibility
- ✅ No backwards compatibility (as requested)
- ✅ All PECL timezones included
- ✅ Comprehensive test coverage
- ✅ Simple, maintainable codebase

## 📝 Related

- Resolves JTDAP-200
- Follows project guidelines in `docs/project-guidelines.txt`
- Nova documentation: https://nova.laravel.com/docs/v5/resources/fields#timezone-field

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author